### PR TITLE
Move symfony/yaml to require dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require-dev": {
     "phpunit/phpunit": "^5.6",
     "jwage/easy-csv": "0.0.3.*",
-    "symfony/yaml": "^3.0"
+    "symfony/yaml": "^2.0|^3.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
   "require": {
     "php": ">=5.5.0",
     "guzzlehttp/guzzle": "^6.2",
-    "incenteev/composer-parameter-handler": "^2.1",
-    "symfony/yaml": "^3.0"
+    "incenteev/composer-parameter-handler": "^2.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6",
-    "jwage/easy-csv": "0.0.3.*"
+    "jwage/easy-csv": "0.0.3.*",
+    "symfony/yaml": "^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I want to use this package with Symfony 2.8, however it required symfony/yaml ^3.0 .

symfony/yaml is only used in a test on my checking, also I moved it to require-dev.

In addition, there were no problem when tested with symfony/yaml ^2.0.