### PR TITLE
Modify URI pattern for CSV

### DIFF
--- a/src/Api/User/Csv.php
+++ b/src/Api/User/Csv.php
@@ -46,7 +46,7 @@ class Csv
         }
 
         $content = (string)$this->client
-            ->get(UserApi::generateUrl("csv/{$type}.json"))
+            ->get(UserApi::generateUrl("csv/{$type}.csv"))
             ->getBody();
 
         return substr($content, 0, -3);


### PR DESCRIPTION
User API からCSVを取得する際、下記の例外が発生する問題を回避する。

```
  [GuzzleHttp\Exception\RequestException] 不正なリクエストです。
```

### 今回の変更の影響を受けるリクエストURIのパターン
https://{sub-domain}.cybozu.com/v1/csv/user.csv
https://{sub-domain}.cybozu.com/v1/csv/title.csv
https://{sub-domain}.cybozu.com/v1/csv/organization.csv
https://{sub-domain}.cybozu.com/v1/csv/group.csv
https://{sub-domain}.cybozu.com/v1/csv/userOrganizations.csv
https://{sub-domain}.cybozu.com/v1/csv/userGroups.csv
https://{sub-domain}.cybozu.com/v1/csv/userServices.csv