### PR TITLE
Modify return format

### DIFF
--- a/src/Api/User/Csv.php
+++ b/src/Api/User/Csv.php
@@ -49,7 +49,7 @@ class Csv
             ->get(UserApi::generateUrl("csv/{$type}.csv"))
             ->getBody();
 
-        return substr($content, 0, -3);
+        return $content;
     }
 
     /**


### PR DESCRIPTION
返却されるCSV値から３文字分消失することで、正常に値を受け取れなくなった問題に対応。