### PR TITLE
Suppress deprecated error for return type of Middleware\JsonStream::jsonSerialize()

### DIFF
--- a/src/Middleware/JsonStream.php
+++ b/src/Middleware/JsonStream.php
@@ -12,6 +12,8 @@ class JsonStream implements StreamInterface, \JsonSerializable
 {
     use StreamDecoratorTrait;
 
+    // TODO: Specify return type as mixed when PHP 7.x support is dropped
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $contents = (string) $this->getContents();


### PR DESCRIPTION
In PHP 8.1, a mixed type definition should be added to the method that implements JsonSerializable::jsonSerialize(). If the type declaration is not written, a Deprecated error will be displayed as shown below.
However, ochi51/cybozu-http supports PHP 7.x and cannot use mixed type declarations.
Instead of using a mixed type declaration, this commit uses the #[\ReturnTypeWillChange] attribute to prevent a Deprecated Error.
This attribute is interpreted as a comment in PHP 7.x, so there is no impact on PHP 7.x.
```
Deprecated: Return type of CybozuHttp\Middleware\JsonStream::jsonSerialize() should either be compatible with
JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be
used to temporarily suppress the notice in ... /src/Middleware/JsonStream.php on line 15
```