### PR TITLE
Pass timeout to guzzle configuration

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -133,7 +133,8 @@ class Config
             'base_uri' => $this->get('base_uri'),
             'headers' => $this->get('headers'),
             'debug' => $this->get('debug') ? fopen($this->get('logfile'), 'ab') : false,
-            'concurrency' => $this->get('concurrency')
+            'concurrency' => $this->get('concurrency'),
+            'timeout' => $this->get('timeout')
         ];
         if ($this->get('auth')) {
             $config['auth'] = $this->get('auth');


### PR DESCRIPTION
Modiffied CybozuHttp/Config::toGuzzleConfig to use timeout option when passed via $config arg to CybozuHttp/Client constructor.
This option is very important since the default behavior of guzzle is to wait indefinitely, and this can cause problems in case request origin service is gone.

yoroshiku onegaishimasu
