### PR TITLE
Fix FinishMiddleware type errors

### DIFF
--- a/src/Middleware/FinishMiddleware.php
+++ b/src/Middleware/FinishMiddleware.php
@@ -58,11 +58,11 @@ class FinishMiddleware
     {
         return static function ($reason) use ($request) {
             if (!($reason instanceof RequestException)) {
-                return $reason;
+                throw $reason;
             }
             $response = $reason->getResponse();
             if ($response === null || $response->getStatusCode() < 300) {
-                return $reason;
+                throw $reason;
             }
             $service = new ResponseService($request, $response);
             if ($service->isJsonResponse()) {
@@ -71,7 +71,7 @@ class FinishMiddleware
                 $service->handleDomError();
             }
 
-            return $reason;
+            throw $reason;
         };
     }
 }

--- a/src/Middleware/FinishMiddleware.php
+++ b/src/Middleware/FinishMiddleware.php
@@ -67,7 +67,7 @@ class FinishMiddleware
             $service = new ResponseService($request, $response);
             if ($service->isJsonResponse()) {
                 $service->handleJsonError();
-            } else {
+            } else if ($service->isHtmlResponse()) {
                 $service->handleDomError();
             }
 

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -45,6 +45,17 @@ class ResponseService
         return is_string($contentType) && strpos($contentType, 'application/json') === 0;
     }
 
+    /**
+     * @return bool
+     */
+    public function isHtmlResponse(): bool
+    {
+        $contentType = $this->response->getHeader('Content-Type');
+        $contentType = is_array($contentType) && isset($contentType[0]) ? $contentType[0] : $contentType;
+
+        return is_string($contentType) && strpos($contentType, 'text/html') === 0;
+    }
+
 
     /**
      * @throws RequestException

--- a/tests/Service/ResponseServiceTest.php
+++ b/tests/Service/ResponseServiceTest.php
@@ -21,6 +21,21 @@ class ResponseServiceTest extends TestCase
         $this->assertTrue($service->isJsonResponse());
     }
 
+    public function testIsHtmlResponse(): void
+    {
+        $request = new Request('GET', '/');
+
+        $htmlResponse = new Response(200, ['Content-Type' => 'text/html; charset=utf-8']);
+        $service = new ResponseService($request, $htmlResponse);
+
+        $this->assertTrue($service->isHtmlResponse());
+
+        $jsonResponse = new Response(200, ['Content-Type' => 'application/json; charset=utf-8']);
+        $service = new ResponseService($request, $jsonResponse);
+
+        $this->assertFalse($service->isHtmlResponse());
+    }
+
     public function testIsNotJsonResponse(): void
     {
         $request = new Request('GET', '/');


### PR DESCRIPTION
6fe46e754231741edddbec48177219ff3fd6b43f
Callback passed to handler should return ResponseInterface implementation or throw a exception.
Since at previous code Exception was being returned, type error at [guzzle side](https://github.com/guzzle/guzzle/blob/7.8/src/ClientTrait.php#L42) was occurring.
Fixed by throwing, not returning, Exception at FinishMiddleware::onRejected.


f77fdb7b8570ebb9eb296dda1bb7dc5d022dc57a
In some cases ResponseService::handleDomError was being called when response content type is not text/html.
Fixed to check content type before executing ResponseService::handleDomError.

