### PR TITLE
Stop supporting guzzle 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "guzzlehttp/guzzle": "^6.2 || ^7.0",
+    "guzzlehttp/guzzle": "^7.0",
     "incenteev/composer-parameter-handler": "^2.1",
     "ext-fileinfo": "*",
     "ext-dom": "*",

--- a/src/Api/Kintone/File.php
+++ b/src/Api/Kintone/File.php
@@ -5,7 +5,6 @@ namespace CybozuHttp\Api\Kintone;
 use CybozuHttp\Client;
 use CybozuHttp\Api\KintoneApi;
 use CybozuHttp\Middleware\JsonStream;
-use CybozuHttp\Service\ResponseService;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Psr7\MultipartStream;
@@ -59,28 +58,7 @@ class File
             'json' => ['fileKey' => $fileKey],
             'stream' => true
         ];
-        $result = $this->client->get(KintoneApi::generateUrl('file.json', $guestSpaceId), $options);
-        if ($result instanceof RequestException) {
-            $this->handleJsonError($result);
-            throw $result;
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param RequestException $result
-     * @throws RequestException
-     */
-    private function handleJsonError(RequestException $result): void
-    {
-        $response = $result->getResponse();
-        if ($response instanceof ResponseInterface) {
-            $service = new ResponseService($result->getRequest(), $response);
-            if ($service->isJsonResponse()) {
-                $service->handleJsonError();
-            }
-        }
+        return $this->client->get(KintoneApi::generateUrl('file.json', $guestSpaceId), $options);
     }
 
     /**


### PR DESCRIPTION
5589b1d
Stopped supporting guzzlehttp/guzzle	v6 past EOL.
https://github.com/guzzle/guzzle?tab=readme-ov-file#version-guidance

6fffb3f
The removed code seemed to be a consideration for the Exception being returned in stream mode.
At least since guzzlehttp/guzzle v7, we can be sure from the type definition that Exception will never be returned.
https://github.com/guzzle/guzzle/blob/7.8/src/ClientTrait.php#L42