### PR TITLE
Handle unknown kintone error response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "guzzlehttp/guzzle": "^6.2 || ^7.0",
+    "guzzlehttp/guzzle": "^7.0",
     "incenteev/composer-parameter-handler": "^2.1",
     "ext-fileinfo": "*",
     "ext-dom": "*",

--- a/src/Api/Kintone/File.php
+++ b/src/Api/Kintone/File.php
@@ -5,7 +5,6 @@ namespace CybozuHttp\Api\Kintone;
 use CybozuHttp\Client;
 use CybozuHttp\Api\KintoneApi;
 use CybozuHttp\Middleware\JsonStream;
-use CybozuHttp\Service\ResponseService;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Psr7\MultipartStream;
@@ -59,28 +58,7 @@ class File
             'json' => ['fileKey' => $fileKey],
             'stream' => true
         ];
-        $result = $this->client->get(KintoneApi::generateUrl('file.json', $guestSpaceId), $options);
-        if ($result instanceof RequestException) {
-            $this->handleJsonError($result);
-            throw $result;
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param RequestException $result
-     * @throws RequestException
-     */
-    private function handleJsonError(RequestException $result): void
-    {
-        $response = $result->getResponse();
-        if ($response instanceof ResponseInterface) {
-            $service = new ResponseService($result->getRequest(), $response);
-            if ($service->isJsonResponse()) {
-                $service->handleJsonError();
-            }
-        }
+        return $this->client->get(KintoneApi::generateUrl('file.json', $guestSpaceId), $options);
     }
 
     /**

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace CybozuHttp\Exception;
+
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Exception/NotExistRequiredException.php
+++ b/src/Exception/NotExistRequiredException.php
@@ -6,4 +6,6 @@ namespace CybozuHttp\Exception;
 /**
  * ochi51<ochiai07@gmail.com>
  */
-class NotExistRequiredException extends \InvalidArgumentException{}
+class NotExistRequiredException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Exception/RedirectResponseException.php
+++ b/src/Exception/RedirectResponseException.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * @author ochi51 <ochiai07@gmail.com>
  */
-class RedirectResponseException extends \Exception
+class RedirectResponseException extends \Exception implements ExceptionInterface
 {
     /**
      * @var ResponseInterface

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CybozuHttp\Exception;
+
+use Throwable;
+
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+    /**
+     * @var array
+     */
+    private $context;
+
+    /**
+     * RuntimeException constructor.
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     * @param array $context
+     */
+    public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null, array $context = [])
+    {
+        $this->context = $context;
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return array
+     */
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+}

--- a/src/Middleware/FinishMiddleware.php
+++ b/src/Middleware/FinishMiddleware.php
@@ -64,7 +64,7 @@ class FinishMiddleware
             if ($response === null || $response->getStatusCode() < 300) {
                 throw $reason;
             }
-            $service = new ResponseService($request, $response);
+            $service = new ResponseService($request, $response, $reason);
             if ($service->isJsonResponse()) {
                 $service->handleJsonError();
             } else if ($service->isHtmlResponse()) {

--- a/src/Middleware/FinishMiddleware.php
+++ b/src/Middleware/FinishMiddleware.php
@@ -65,13 +65,7 @@ class FinishMiddleware
                 throw $reason;
             }
             $service = new ResponseService($request, $response, $reason);
-            if ($service->isJsonResponse()) {
-                $service->handleJsonError();
-            } else if ($service->isHtmlResponse()) {
-                $service->handleDomError();
-            }
-
-            throw $reason;
+            $service->handleError();
         };
     }
 }

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -120,7 +120,11 @@ class ResponseService
     private function handleJsonError(): void
     {
         $body = $this->getResponseBody();
-        $json = \GuzzleHttp\json_decode($body, true);
+        try {
+            $json = \GuzzleHttp\json_decode($body, true);
+        } catch (\InvalidArgumentException) {
+            throw $this->createRuntimeException('Failed to decode JSON response.');
+        }
 
         $message = $json['message'];
         if (isset($json['errors']) && is_array($json['errors'])) {

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -81,7 +81,7 @@ class ResponseService
             $this->handleDomError();
         }
 
-        throw $this->previousThrowable;
+        throw $this->createRuntimeException('Failed to extract error message because Content-Type of error response is unexpected.');
     }
 
     /**

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -133,6 +133,9 @@ class ResponseService
         if (isset($json['errors']) && is_array($json['errors'])) {
             $message .= $this->addErrorMessages($json['errors']);
         }
+        if (is_null($message) && isset($json['reason'])) {
+            $message = $json['reason'];
+        }
 
         if (is_null($message)) {
             throw $this->createRuntimeException('Failed to extract error message from JSON response.');

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -69,12 +69,26 @@ class ResponseService
         return is_string($contentType) && strpos($contentType, 'text/html') === 0;
     }
 
+    /**
+     * @throws RequestException
+     * @throws RuntimeException
+     */
+    public function handleError(): void
+    {
+        if ($this->isJsonResponse()) {
+            $this->handleJsonError();
+        } else if ($this->isHtmlResponse()) {
+            $this->handleDomError();
+        }
+
+        throw $this->previousThrowable;
+    }
 
     /**
      * @throws RequestException
      * @throws RuntimeException
      */
-    public function handleDomError(): void
+    private function handleDomError(): void
     {
         $body = $this->getResponseBody();
         $dom = new \DOMDocument('1.0', 'UTF-8');
@@ -110,7 +124,7 @@ class ResponseService
      * @throws RequestException
      * @throws RuntimeException
      */
-    public function handleJsonError(): void
+    private function handleJsonError(): void
     {
         $body = $this->getResponseBody();
         $json = \GuzzleHttp\json_decode($body, true);

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -146,7 +146,7 @@ class ResponseService
      * @param string $message
      * @return RequestException
      */
-    private function createException($message): RequestException
+    private function createException(string $message): RequestException
     {
         $level = (int) floor($this->response->getStatusCode() / 100);
         $className = RequestException::class;

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -117,8 +117,6 @@ class ResponseService
             $json = \GuzzleHttp\json_decode($body, true);
         } catch (\InvalidArgumentException $e) {
             return;
-        } catch (\RuntimeException $e) {
-            return;
         }
 
         $message = $json['message'];

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -99,22 +99,15 @@ class ResponseService
             if (is_object($title)) {
                 $title = $title->item(0)->nodeValue;
             }
-            if ($title === 'Error') {
-                $message = $dom->getElementsByTagName('h3')->item(0)->nodeValue;
-                if (is_null($message)) {
-                    throw $this->createRuntimeException('Failed to extract error message from DOM response.');
-                }
-                throw $this->createException($message);
+            $message = match ($title) {
+                'Error' => $dom->getElementsByTagName('h3')->item(0)->nodeValue,
+                'Unauthorized' => $dom->getElementsByTagName('h2')->item(0)->nodeValue,
+                default => 'Invalid auth.',
+            };
+            if (is_null($message)) {
+                throw $this->createRuntimeException('Failed to extract error message from DOM response.');
             }
-            if ($title === 'Unauthorized') {
-                $message = $dom->getElementsByTagName('h2')->item(0)->nodeValue;
-                if (is_null($message)) {
-                    throw $this->createRuntimeException('Failed to extract error message from DOM response.');
-                }
-                throw $this->createException($message);
-            }
-
-            throw $this->createException('Invalid auth.');
+            throw $this->createException($message);
         }
 
         throw new \InvalidArgumentException('Body is not DOM.');

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -112,12 +112,8 @@ class ResponseService
      */
     public function handleJsonError(): void
     {
-        try {
-            $body = $this->getResponseBody();
-            $json = \GuzzleHttp\json_decode($body, true);
-        } catch (\InvalidArgumentException $e) {
-            return;
-        }
+        $body = $this->getResponseBody();
+        $json = \GuzzleHttp\json_decode($body, true);
 
         $message = $json['message'];
         if (isset($json['errors']) && is_array($json['errors'])) {

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -25,14 +25,21 @@ class ResponseService
     private $response;
 
     /**
+     * @var \Throwable|null
+     */
+    private $previousThrowable;
+
+    /**
      * ResponseService constructor.
      * @param RequestInterface $request
      * @param ResponseInterface $response
+     * @param \Throwable|null $previousThrowable
      */
-    public function __construct(RequestInterface $request, ResponseInterface $response)
+    public function __construct(RequestInterface $request, ResponseInterface $response, ?\Throwable $previousThrowable = null)
     {
         $this->request = $request;
         $this->response = $response;
+        $this->previousThrowable = $previousThrowable;
     }
 
     /**
@@ -166,6 +173,10 @@ class ResponseService
      */
     private function createRuntimeException(string $message): RuntimeException
     {
-        return new RuntimeException($message);
+        return new RuntimeException(
+            $message,
+            0,
+            $this->previousThrowable
+        );
     }
 }

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -134,7 +134,7 @@ class ResponseService
      * @param string $message
      * @return RequestException
      */
-    public function createException($message): RequestException
+    private function createException($message): RequestException
     {
         $level = (int) floor($this->response->getStatusCode() / 100);
         $className = RequestException::class;

--- a/src/Service/ResponseService.php
+++ b/src/Service/ResponseService.php
@@ -110,7 +110,7 @@ class ResponseService
             throw $this->createException($message);
         }
 
-        throw new \InvalidArgumentException('Body is not DOM.');
+        throw $this->createRuntimeException('Failed to parse DOM response.');
     }
 
     /**

--- a/tests/Service/ResponseServiceTest.php
+++ b/tests/Service/ResponseServiceTest.php
@@ -75,6 +75,7 @@ class ResponseServiceTest extends TestCase
             $this->assertInstanceOf(RuntimeException::class, $e);
             $this->assertEquals($e->getMessage(), 'Failed to extract error message from DOM response.');
             $this->assertEquals($e->getPrevious(), $exception);
+            $this->assertEquals($e->getContext()['responseBody'], $dom);
         }
 
         $dom = '<title>Error</title><h3>bad request</h3>';
@@ -102,6 +103,7 @@ class ResponseServiceTest extends TestCase
             $this->assertInstanceOf(RuntimeException::class, $e);
             $this->assertEquals($e->getMessage(), 'Failed to extract error message from DOM response.');
             $this->assertEquals($e->getPrevious(), $exception);
+            $this->assertEquals($e->getContext()['responseBody'], $dom);
         }
 
         $dom = '<title>Unauthorized</title><h2>Bad authorized</h2>';
@@ -187,6 +189,7 @@ class ResponseServiceTest extends TestCase
             $this->assertInstanceOf(RuntimeException::class, $e);
             $this->assertEquals($e->getMessage(), 'Failed to extract error message from JSON response.');
             $this->assertEquals($e->getPrevious(), $exception);
+            $this->assertEquals($e->getContext()['responseBody'], $body);
         }
 
         /** @var Response|MockObject $response */

--- a/tests/Service/ResponseServiceTest.php
+++ b/tests/Service/ResponseServiceTest.php
@@ -210,7 +210,10 @@ class ResponseServiceTest extends TestCase
             $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
-            $this->assertInstanceOf(\InvalidArgumentException::class, $e);
+            $this->assertInstanceOf(RuntimeException::class, $e);
+            $this->assertEquals($e->getMessage(), 'Failed to decode JSON response.');
+            $this->assertEquals($e->getPrevious(), $exception);
+            $this->assertEquals($e->getContext()['responseBody'], $body);
         }
 
         $body = json_encode([

--- a/tests/Service/ResponseServiceTest.php
+++ b/tests/Service/ResponseServiceTest.php
@@ -46,7 +46,7 @@ class ResponseServiceTest extends TestCase
         $this->assertFalse($service->isJsonResponse());
     }
 
-    public function testHandleDomError(): void
+    public function testHandleError(): void
     {
         $request = new Request('GET', '/');
         $dom = '<title>Bad request</title><div>bad request</div>';
@@ -55,7 +55,7 @@ class ResponseServiceTest extends TestCase
         $service = new ResponseService($request, $response, $exception);
 
         try {
-            $service->handleDomError();
+            $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(ClientException::class, $e);
@@ -68,7 +68,7 @@ class ResponseServiceTest extends TestCase
         $service = new ResponseService($request, $response, $exception);
 
         try {
-            $service->handleDomError();
+            $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(RuntimeException::class, $e);
@@ -83,7 +83,7 @@ class ResponseServiceTest extends TestCase
         $service = new ResponseService($request, $response, $exception);
 
         try {
-            $service->handleDomError();
+            $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(ClientException::class, $e);
@@ -96,7 +96,7 @@ class ResponseServiceTest extends TestCase
         $service = new ResponseService($request, $response, $exception);
 
         try {
-            $service->handleDomError();
+            $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(RuntimeException::class, $e);
@@ -111,7 +111,7 @@ class ResponseServiceTest extends TestCase
         $service = new ResponseService($request, $response, $exception);
 
         try {
-            $service->handleDomError();
+            $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(ClientException::class, $e);
@@ -124,15 +124,12 @@ class ResponseServiceTest extends TestCase
         $service = new ResponseService($request, $response, $exception);
 
         try {
-            $service->handleDomError();
+            $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(ServerException::class, $e);
         }
-    }
 
-    public function testHandleJsonError(): void
-    {
         $request = new Request('GET', '/');
         $body = json_encode([
             'message' => 'simple error',
@@ -149,7 +146,7 @@ class ResponseServiceTest extends TestCase
         $exception = new RequestException('raw error', $request, $response);
         $service = new ResponseService($request, $response, $exception);
         try {
-            $service->handleJsonError();
+            $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(ClientException::class, $e);
@@ -168,7 +165,7 @@ class ResponseServiceTest extends TestCase
         $exception = new RequestException('raw error', $request, $response);
         $service = new ResponseService($request, $response, $exception);
         try {
-            $service->handleJsonError();
+            $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(ClientException::class, $e);
@@ -182,7 +179,7 @@ class ResponseServiceTest extends TestCase
         $exception = new RequestException('raw error', $request, $response);
         $service = new ResponseService($request, $response, $exception);
         try {
-            $service->handleJsonError();
+            $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(RuntimeException::class, $e);
@@ -196,7 +193,7 @@ class ResponseServiceTest extends TestCase
         $exception = new RequestException('raw error', $request, $response);
         $service = new ResponseService($request, $response, $exception);
         try {
-            $service->handleJsonError();
+            $service->handleError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(\InvalidArgumentException::class, $e);

--- a/tests/Service/ResponseServiceTest.php
+++ b/tests/Service/ResponseServiceTest.php
@@ -194,14 +194,6 @@ class ResponseServiceTest extends TestCase
 
         /** @var Response|MockObject $response */
         $response = $this->createMock(Response::class);
-        $response->method('getBody')->willThrowException(new \RuntimeException(''));
-        $exception = new RequestException('raw error', $request, $response);
-        $service = new ResponseService($request, $response, $exception);
-        $service->handleJsonError();
-        $this->assertTrue(true);
-
-        /** @var Response|MockObject $response */
-        $response = $this->createMock(Response::class);
         $response->method('getBody')->willThrowException(new \InvalidArgumentException(''));
         $exception = new RequestException('raw error', $request, $response);
         $service = new ResponseService($request, $response, $exception);

--- a/tests/Service/ResponseServiceTest.php
+++ b/tests/Service/ResponseServiceTest.php
@@ -173,6 +173,20 @@ class ResponseServiceTest extends TestCase
         }
 
         $body = json_encode([
+            'reason' => 'simple error',
+        ]);
+        $response = new Response(400, ['Content-Type' => 'application/json; charset=utf-8'], $body);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
+        try {
+            $service->handleError();
+            $this->assertTrue(false);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(ClientException::class, $e);
+            $this->assertEquals($e->getMessage(), 'simple error');
+        }
+
+        $body = json_encode([
             'unknown' => 'simple error',
         ]);
         $response = new Response(400, ['Content-Type' => 'application/json; charset=utf-8'], $body);

--- a/tests/Service/ResponseServiceTest.php
+++ b/tests/Service/ResponseServiceTest.php
@@ -198,5 +198,21 @@ class ResponseServiceTest extends TestCase
         } catch (\Exception $e) {
             $this->assertInstanceOf(\InvalidArgumentException::class, $e);
         }
+
+        $body = json_encode([
+            'message' => 'simple error',
+        ]);
+        $response = new Response(400, ['Content-Type' => 'text/plain; charset=utf-8'], $body);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
+        try {
+            $service->handleError();
+            $this->assertTrue(false);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(RuntimeException::class, $e);
+            $this->assertEquals($e->getMessage(), 'Failed to extract error message because Content-Type of error response is unexpected.');
+            $this->assertEquals($e->getPrevious(), $exception);
+            $this->assertEquals($e->getContext()['responseBody'], $body);
+        }
     }
 }

--- a/tests/Service/ResponseServiceTest.php
+++ b/tests/Service/ResponseServiceTest.php
@@ -7,7 +7,6 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Exception\RequestException;
 
@@ -192,12 +191,15 @@ class ResponseServiceTest extends TestCase
             $this->assertEquals($e->getContext()['responseBody'], $body);
         }
 
-        /** @var Response|MockObject $response */
-        $response = $this->createMock(Response::class);
-        $response->method('getBody')->willThrowException(new \InvalidArgumentException(''));
+        $body = 'invalid json';
+        $response = new Response(400, ['Content-Type' => 'application/json; charset=utf-8'], $body);
         $exception = new RequestException('raw error', $request, $response);
         $service = new ResponseService($request, $response, $exception);
-        $service->handleJsonError();
-        $this->assertTrue(true);
+        try {
+            $service->handleJsonError();
+            $this->assertTrue(false);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(\InvalidArgumentException::class, $e);
+        }
     }
 }

--- a/tests/Service/ResponseServiceTest.php
+++ b/tests/Service/ResponseServiceTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Exception\RequestException;
 
 class ResponseServiceTest extends TestCase
 {
@@ -51,7 +52,8 @@ class ResponseServiceTest extends TestCase
         $request = new Request('GET', '/');
         $dom = '<title>Bad request</title><div>bad request</div>';
         $response = new Response(400, ['Content-Type' => 'text/html; charset=utf-8'], $dom);
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
 
         try {
             $service->handleDomError();
@@ -63,7 +65,8 @@ class ResponseServiceTest extends TestCase
 
         $dom = '<title>Error</title>';
         $response = new Response(400, ['Content-Type' => 'text/html; charset=utf-8'], $dom);
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
 
         try {
             $service->handleDomError();
@@ -71,11 +74,13 @@ class ResponseServiceTest extends TestCase
         } catch (\Exception $e) {
             $this->assertInstanceOf(RuntimeException::class, $e);
             $this->assertEquals($e->getMessage(), 'Failed to extract error message from DOM response.');
+            $this->assertEquals($e->getPrevious(), $exception);
         }
 
         $dom = '<title>Error</title><h3>bad request</h3>';
         $response = new Response(400, ['Content-Type' => 'text/html; charset=utf-8'], $dom);
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
 
         try {
             $service->handleDomError();
@@ -87,7 +92,8 @@ class ResponseServiceTest extends TestCase
 
         $dom = '<title>Unauthorized</title>';
         $response = new Response(400, ['Content-Type' => 'text/html; charset=utf-8'], $dom);
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
 
         try {
             $service->handleDomError();
@@ -95,11 +101,13 @@ class ResponseServiceTest extends TestCase
         } catch (\Exception $e) {
             $this->assertInstanceOf(RuntimeException::class, $e);
             $this->assertEquals($e->getMessage(), 'Failed to extract error message from DOM response.');
+            $this->assertEquals($e->getPrevious(), $exception);
         }
 
         $dom = '<title>Unauthorized</title><h2>Bad authorized</h2>';
         $response = new Response(400, ['Content-Type' => 'text/html; charset=utf-8'], $dom);
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
 
         try {
             $service->handleDomError();
@@ -111,7 +119,8 @@ class ResponseServiceTest extends TestCase
 
         $dom = '<title>Bad server</title><div>bad server</div>';
         $response = new Response(500, ['Content-Type' => 'text/html; charset=utf-8'], $dom);
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
 
         try {
             $service->handleDomError();
@@ -136,7 +145,8 @@ class ResponseServiceTest extends TestCase
             ]
         ]);
         $response = new Response(400, ['Content-Type' => 'application/json; charset=utf-8'], $body);
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
         try {
             $service->handleJsonError();
             $this->assertTrue(false);
@@ -154,7 +164,8 @@ class ResponseServiceTest extends TestCase
             ]
         ]);
         $response = new Response(400, ['Content-Type' => 'application/json; charset=utf-8'], $body);
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
         try {
             $service->handleJsonError();
             $this->assertTrue(false);
@@ -167,26 +178,30 @@ class ResponseServiceTest extends TestCase
             'unknown' => 'simple error',
         ]);
         $response = new Response(400, ['Content-Type' => 'application/json; charset=utf-8'], $body);
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
         try {
             $service->handleJsonError();
             $this->assertTrue(false);
         } catch (\Exception $e) {
             $this->assertInstanceOf(RuntimeException::class, $e);
             $this->assertEquals($e->getMessage(), 'Failed to extract error message from JSON response.');
+            $this->assertEquals($e->getPrevious(), $exception);
         }
 
         /** @var Response|MockObject $response */
         $response = $this->createMock(Response::class);
         $response->method('getBody')->willThrowException(new \RuntimeException(''));
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
         $service->handleJsonError();
         $this->assertTrue(true);
 
         /** @var Response|MockObject $response */
         $response = $this->createMock(Response::class);
         $response->method('getBody')->willThrowException(new \InvalidArgumentException(''));
-        $service = new ResponseService($request, $response);
+        $exception = new RequestException('raw error', $request, $response);
+        $service = new ResponseService($request, $response, $exception);
         $service->handleJsonError();
         $this->assertTrue(true);
     }


### PR DESCRIPTION
Changed to throw `CybozuHttp\Exception\RuntimeException` when error response from kintone is in unexpected format.